### PR TITLE
Process DMCA request

### DIFF
--- a/2020/02/2020-02-26-zffriedrichshafen.md
+++ b/2020/02/2020-02-26-zffriedrichshafen.md
@@ -1,0 +1,59 @@
+**Are you the copyright holder or authorized to act on the copyright owner's behalf?**
+
+Yes, I am authorized to act on the copyright owner's behalf.
+
+**Please describe the nature of your copyright ownership or authorization to act on the owner's behalf.**
+
+My name is [private] and I am an authorized representative of ZF Friedrichshafen. It has come to our attention that proprietary documentation owned by ZF. I work with ZF as IT Security Forensics Consultant.
+
+**Please provide a detailed description of the original copyrighted work that has allegedly been infringed. If possible, include a URL to where it is posted online.**
+
+Dear Sir / Madam,
+
+Post on Github from the user 'linstyle'/修改主页提示 ([private]) contained credentials to what appears to be an SQL database. At the time of writing, we were unable to confirm whether the database was a ZF Friedrichshafen asset. However, the following ZF email domains have been extracted from the post. The post was dated 05 Aug 2012.
+
+My name is [private] and I am an authorized representative of ZF Friedrichshafen. It has come to our attention that proprietary documentation owned by ZF Friedrichshafen is available at the following URL:
+
+https://github.com/linstyle/ZhongFans/blob/master/ZhongFansSQL/back.sql
+
+Identifiable client email domains with associated passwords located on Github.
+
+We would ask that you please remove these materials from public facing sections of your website.
+
+Kindly send a response to this email confirming that the above request has been completed.
+
+**What files should be taken down? Please provide URLs for each file, or if the entire repository, the repository’s URL.**
+
+https://github.com/linstyle/ZhongFans/blob/master/ZhongFansSQL/back.sql
+
+**Have you searched for any forks of the allegedly infringing files or repositories? Each fork is a distinct repository and must be identified separately if you believe it is infringing and wish to have it taken down.**
+
+No
+
+**Is the work licensed under an open source license? If so, which open source license? Are the allegedly infringing files being used under the open source license, or are they in violation of the license?**
+
+no
+
+**What would be the best solution for the alleged infringement? Are there specific changes the other person can make other than removal? Can the repository be made private?**
+
+Please remove the content from the above mentioned URL
+
+**Do you have the alleged infringer’s contact information? If so, please provide it.**
+
+No
+
+**I have a good faith belief that use of the copyrighted materials described above on the infringing web pages is not authorized by the copyright owner, or its agent, or the law.**
+
+**I have taken <a href="https://www.lumendatabase.org/topics/22">fair use</a> into consideration.**
+
+**I swear, under penalty of perjury, that the information in this notification is accurate and that I am the copyright owner, or am authorized to act on behalf of the owner, of an exclusive right that is allegedly infringed.**
+
+**I have read and understand GitHub's <a href="https://help.github.com/articles/guide-to-submitting-a-dmca-takedown-notice/">Guide to Submitting a DMCA Takedown Notice</a>.**
+
+**So that we can get back to you, please provide either your telephone number or physical address.**
+
+[private]
+
+**Please type your full legal name below to sign this request.**
+
+[private]


### PR DESCRIPTION
### Description

In this pull request, the user has added a template for a DMCA takedown notice related to copyrighted materials allegedly posted on a GitHub repository by a user named 'linstyle'. The notice is on behalf of ZF Friedrichshafen and requests the removal of sensitive information related to identifiable client email domains with associated passwords from the specified URL.

Below are the summarized changes in the code:
- Addition of a DMCA takedown notice template for copyrighted materials posted on a GitHub repository.
- The notice includes details such as copyright ownership, description of the alleged infringement, request for specific files to be taken down, consideration of fair use, and contact information for the copyright representative.
