### PR TITLE
Process DMCA request

### DIFF
--- a/2019/03/2019-03-22-SiliconLabs.md
+++ b/2019/03/2019-03-22-SiliconLabs.md
@@ -1,0 +1,47 @@
+Dear GitHub Staff:  
+
+Takedown Notice under DMCA  
+
+Date: March 21, 2019  
+
+Dear GitHub Copyright Agent:  
+
+I, the undersigned, state UNDER PENALTY OF PERJURY that:  
+
+[1] I am, a person injured, or an agent authorized to act on behalf of a person injured by a violation of the U.S. Copyright laws, in particular section(s) 1201(a)(2) and/or 1201(b)(1) of Title 17 of the United States Code, commonly referred to as the Digital Millennium Copyright Act, or "DMCA";  
+
+[2] I May Be Contacted At:  
+
+Name of Injured Party: SILICON LABORATORIES INC. ("Silicon Labs")  
+
+Name and Title: [private]  
+
+Company: SILICON LABORATORIES INC.    
+
+Address: 400 West Cesar Chavez  
+
+City, State, and Zip: Austin, Texas 78701 Email address: [private]  
+
+Telephone: [private]  
+
+Fax: [private]  
+
+[3] I have read and understand GitHub’s Guide to Filing a DMCA Notice. I have a good faith belief that the use of the copyrighted materials described below on the infringing web pages is not authorized by the copyright owner, or its agent, or the law. I have a good faith belief that the file-downloads identified below (by URL) are unlawful under these laws because, among other things, the files are unauthorized copies of Silicon Labs' copyrighted code.
+
+[4] Reason: Content Type: "Custom Firmware" files  
+
+Violation(s): Trafficking software code that is in violation of copyright protection.  
+
+[5] Please act expeditiously to remove the file-downloads found at the following URLs:  
+
+The entire forked repository at:  
+
+https://github.com/grinbergzvika/WDS  
+
+[6] I swear, under penalty of perjury, that the information in this notification is accurate and that I am the copyright owner, or am authorized to act on behalf of the owner, of an exclusive right that is allegedly infringed.  
+
+ 
+
+/[private]/
+
+ 


### PR DESCRIPTION
### Description

The code diff in this PR is adding a DMCA takedown notice to the file "2019-03-22-SiliconLabs.md". This notice contains information such as the date, the injured party (Silicon Laboratories Inc.), contact details, a statement about the violation of copyright laws, the reason for the takedown request (content type: "Custom Firmware" files), and the URLs to the infringing content.

- Add a DMCA takedown notice to the file "2019-03-22-SiliconLabs.md" with detailed information regarding the copyright infringement issue reported.
- Include contact details of the injured party (Silicon Laboratories Inc.), address, and reasoning behind the takedown request.

This PR states a formal DMCA takedown notice on GitHub addressing a copyright infringement issue involving Silicon Laboratories Inc. and the unauthorized distribution of copyrighted "Custom Firmware" files.