### PR TITLE
Process DMCA request

### DIFF
--- a/2021/06/2021-06-07-adobe.md
+++ b/2021/06/2021-06-07-adobe.md
@@ -1,0 +1,47 @@
+**Are you the copyright holder or authorized to act on the copyright owner's behalf?**
+
+Yes, I am authorized to act on the copyright owner's behalf.
+
+**Please describe the nature of your copyright ownership or authorization to act on the owner's behalf.**
+
+Adobe Inc. is the copyright owner and I am authorized to act on its behalf.
+
+**Please provide a detailed description of the original copyrighted work that has allegedly been infringed. If possible, include a URL to where it is posted online.**
+
+Our Adobe Framework Template has been infringed. The files in question contain our proprietary Adobe Inc. owned copyrighted materials (software code).
+
+**What files should be taken down? Please provide URLs for each file, or if the entire repository, the repository’s URL.**
+
+https://github.com/raunakbagri/Framework-Template
+
+**Have you searched for any forks of the allegedly infringing files or repositories? Each fork is a distinct repository and must be identified separately if you believe it is infringing and wish to have it taken down.**
+
+It does not appear to us that there are any forks of the code.
+
+**Is the work licensed under an open source license? If so, which open source license? Are the allegedly infringing files being used under the open source license, or are they in violation of the license?**
+
+No.
+
+**What would be the best solution for the alleged infringement? Are there specific changes the other person can make other than removal? Can the repository be made private?**
+
+Please remove the above infringing files.
+
+**Do you have the alleged infringer’s contact information? If so, please provide it.**
+
+No.
+
+**I have a good faith belief that use of the copyrighted materials described above on the infringing web pages is not authorized by the copyright owner, or its agent, or the law.**
+
+**I have taken <a href="https://www.lumendatabase.org/topics/22">fair use</a> into consideration.**
+
+**I swear, under penalty of perjury, that the information in this notification is accurate and that I am the copyright owner, or am authorized to act on behalf of the owner, of an exclusive right that is allegedly infringed.**
+
+**I have read and understand GitHub's <a href="https://docs.github.com/articles/guide-to-submitting-a-dmca-takedown-notice/">Guide to Submitting a DMCA Takedown Notice</a>.**
+
+**So that we can get back to you, please provide either your telephone number or physical address.**
+
+[private]
+
+**Please type your full legal name below to sign this request.**
+
+[private]


### PR DESCRIPTION
If you are looking to file or dispute a takedown notice by posting to this repository, please STOP :stop_sign: because we do not accept Pull Requests or other contributions to this repository.

Read on to learn about the available paths forward.

Please note that re-posting the exact same content that was the subject of a takedown notice without following the proper process ([outlined below](#responding-to-a-dmca-notice)) is a violation of GitHub’s [DMCA Policy](https://docs.github.com/en/github/site-policy/dmca-takedown-policy) and [Terms of Service](https://docs.github.com/en/github/site-policy/github-acceptable-use-policies). If you commit or post content to this repository that violates our Terms of Service, we will delete that content and may suspend access to your account as well.


#### Submitting a DMCA Notice

If you are a copyright owner wishing to submit a takedown notice, read our [DMCA Policy](https://docs.github.com/en/free-pro-team@latest/github/site-policy/dmca-takedown-policy) and [Guide to Submitting a DMCA Takedown Notice](https://docs.github.com/en/free-pro-team@latest/github/site-policy/guide-to-submitting-a-dmca-takedown-notice). You can submit the actual notice using our special [Copyright Claims Contact Form](https://github.com/contact/dmca).


#### Responding to a DMCA Notice

If you are the owner of a repository that has been taken down, you have two main options:

  - Do you want to [make changes](https://docs.github.com/en/free-pro-team@latest/github/site-policy/dmca-takedown-policy#c-what-if-i-inadvertently-missed-the-window-to-make-changes) to the repository that would remove the allegedly infringing content? If that is possible in your case, [contact us](https://support.github.com/contact) to let us know that you would like to make the changes.

  - Do you want to formally dispute the action by [submitting a counter notice](https://docs.github.com/en/free-pro-team@latest/github/site-policy/guide-to-submitting-a-dmca-counter-notice)? Maybe the person sending the takedown notice does not hold the copyright or did not realize that you have a license or made some other mistake in their takedown notice. If you believe your content on GitHub was mistakenly disabled by a DMCA takedown request, you have the right to contest the takedown by [submitting a counter notice](https://docs.github.com/en/free-pro-team@latest/github/site-policy/guide-to-submitting-a-dmca-counter-notice). If you do, we will wait 10-14 days and then re-enable your content unless the copyright owner initiates a legal action before then.

If you do not want to make changes or dispute the notice, but still have general concerns about the copyright laws and how they apply in your case, know that GitHub and developers have the opportunity and a voice to advocate for changes in law and public policy to better support software development. We are constantly looking to [advocate for developers](https://github.blog/category/company/policy/), so feel free to [reach out](https://support.github.com/contact) and let us know your concerns. We also encourage you to [learn more about copyright and speak up](https://docs.github.com/en/free-pro-team@latest/github/site-policy/dmca-takedown-policy#learn-more-and-speak-up) by reaching out to the Copyright Office or your local lawmakers to voice your concerns.
